### PR TITLE
Correct argument parse

### DIFF
--- a/src/clone.sh
+++ b/src/clone.sh
@@ -63,7 +63,7 @@ function clone_multiple_repositories()
 	local       user="$1"
 
 	local repositories=()
-	for i in ${@:2}; do
+	for i in "${@:2}"; do
 		repositories+=("$i")
 	done
 
@@ -92,7 +92,7 @@ function clone_multiple_repositories()
 	# Echo
 	echo "clone $user [${@:2}] $target $flag_R $flag_v"
 
-	for repo in ${@:2}; do
+	for repo in "${@:2}"; do
 		git clone "$clone_url_base/$repo" $target $flag_R $flag_v
 	done
 


### PR DESCRIPTION
Before:

```
bash test.sh 1 2 3 '4 5 6 7 8 9'
-> 2
-> 3
-> 4
-> 5
-> 6
-> 7
-> 8
-> 9
```

After:

```
bash test.sh 1 2 3 '4 5 6 7' 8 9
-> 2
-> 3
-> 4 5 6 7
-> 8
-> 9
```